### PR TITLE
Fixed accessibility issue with the page title

### DIFF
--- a/config/filters/includes.js
+++ b/config/filters/includes.js
@@ -1,0 +1,7 @@
+module.exports = function(eleventyConfig) {
+
+  eleventyConfig.addFilter("includes", function(array, value) {
+    return Array.isArray(array) && array.includes(value);
+  });
+
+};

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -48,6 +48,7 @@ module.exports = async function (eleventyConfig) {
   require("./config/filters/flatten-navigation.js")(eleventyConfig);
   require("./config/filters/markdown-path-prefix.js")(eleventyConfig);
   require("./config/filters/find-by-url.js")(eleventyConfig);
+  require("./config/filters/includes.js")(eleventyConfig);
 
 
   // Plugins

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -10,7 +10,13 @@
 <html lang="{{ htmlLang | default("en", true) }}" class="govuk-template {%- if htmlClasses %} {{ htmlClasses }}{% endif %}">
 <head>
   <meta charset="utf-8">
-  <title>{{ meta.serviceName }} - {{ meta.siteName }}</title>
+
+  {% if tags | includes("fitnote") %}
+    <title>{{ meta.serviceName }}{% if "fitnote" %}: {{ title }}{% endif %} - {{ meta.siteName }}</title>
+  {% else %}
+    <title>{{ title }} - {{ meta.siteName }}</title>
+  {% endif %}
+
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="{{ themeColor | default('#0b0c0c', true) }}">
 

--- a/src/_pages/accessibility-statement.md
+++ b/src/_pages/accessibility-statement.md
@@ -4,7 +4,7 @@ title: Accessibility statement
 permalink: /accessibility-statement/
 ---
 
-# Accessibility
+# Accessibility statement
 
 This website is run by Government Digital Service. We want as many people as possible to be able to use this website. For example, that means you should be able to:
 

--- a/src/_pages/cookies-and-privacy-policy.md
+++ b/src/_pages/cookies-and-privacy-policy.md
@@ -1,6 +1,6 @@
 ---
 layout: cookies.njk
-title: Cookies
+title: Cookies and privacy policy
 permalink: /cookies-and-privacy-policy/
 ---
 


### PR DESCRIPTION
### What this PR fixes

Previously, the page title remained the same across all pages:  
**`Find support if you have a fit note - GOV.UK`**

This made it harder for users and assistive technologies (like screen readers) to understand what each page was about.

---

### What’s changed

This PR updates the page titles so they reflect the content of the page.  
This improves **accessibility**, **usability**, and clarity for **screen reader users**.

---

### New page titles

Here are the updated titles:

- **Find support after a fit note: Overview** – GOV.UK  
- **Find support after a fit note: Fit notes and sick pay** – GOV.UK  
- **Find support after a fit note: Keeping others informed while you’re off work** – GOV.UK  
- **Find support after a fit note: Benefits and other financial help** – GOV.UK  
- **Find support after a fit note: Support for your health and wellbeing** – GOV.UK  
- **Find support after a fit note: Preparing to return to work** – GOV.UK  
- **Find support after a fit note: When you’re back at work** – GOV.UK  
- **Find support after a fit note: What to do if you can’t return to work or your job has to change** – GOV.UK  
- **Cookies and privacy policy** – GOV.UK  
- **Accessibility statement** – GOV.UK  
